### PR TITLE
implement the feature for specifying defaults

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub enum BuilderError {
     Enum(syn::DataEnum),
     Union(syn::DataUnion),

--- a/tests/default_values.rs
+++ b/tests/default_values.rs
@@ -1,0 +1,44 @@
+#[derive(Default)]
+pub struct MyParam {
+    param: usize,
+}
+
+#[derive(tidy_builder::Builder)]
+struct MyStruct<'a> {
+    #[builder(default)]
+    my_param: MyParam,
+
+    #[builder(default = 3)]
+    my_usize: usize,
+
+    #[builder(default = 1.2)]
+    my_float: f64,
+
+    #[builder(default = "Name")]
+    my_name: &'a str,
+
+    #[builder(default = false)]
+    my_flag: bool,
+
+    req1: usize,
+    req2: usize,
+    opt1: Option<usize>,
+    opt2: Option<usize>,
+}
+
+#[test]
+fn default_values() {
+    let my_struct = MyStruct::builder().req1(1).req2(2).build();
+
+    assert_eq!(my_struct.my_param.param, 0);
+    assert_eq!(my_struct.my_usize, 3);
+    assert_eq!(my_struct.my_float, 1.2);
+    assert_eq!(my_struct.my_name, "Name");
+    assert!(!my_struct.my_flag);
+
+    assert_eq!(my_struct.req1, 1);
+    assert_eq!(my_struct.req2, 2);
+
+    assert_eq!(my_struct.opt1, None);
+    assert_eq!(my_struct.opt2, None);
+}

--- a/tests/default_values_for_optionals.rs
+++ b/tests/default_values_for_optionals.rs
@@ -1,0 +1,46 @@
+#[derive(Default)]
+pub struct MyParam {
+    param: usize,
+}
+
+#[derive(tidy_builder::Builder)]
+struct MyStruct<'a> {
+    #[builder(default)]
+    my_param: MyParam,
+
+    #[builder(default = 3)]
+    my_usize: usize,
+
+    #[builder(default = 1.2)]
+    my_float: f64,
+
+    #[builder(default = "Name")]
+    my_name: &'a str,
+
+    #[builder(default = false)]
+    my_flag: bool,
+
+    #[builder(default)]
+    opt2: Option<usize>,
+
+    req1: usize,
+    req2: usize,
+    opt1: Option<usize>,
+}
+
+#[test]
+fn default_values() {
+    let my_struct = MyStruct::builder().req1(1).req2(2).build();
+
+    assert_eq!(my_struct.my_param.param, 0);
+    assert_eq!(my_struct.my_usize, 3);
+    assert_eq!(my_struct.my_float, 1.2);
+    assert_eq!(my_struct.my_name, "Name");
+    assert!(!my_struct.my_flag);
+
+    assert_eq!(my_struct.req1, 1);
+    assert_eq!(my_struct.req2, 2);
+
+    assert_eq!(my_struct.opt1, None);
+    assert_eq!(my_struct.opt2, None);
+}

--- a/tests/ui/default_value_for_non_default_field.rs
+++ b/tests/ui/default_value_for_non_default_field.rs
@@ -1,0 +1,42 @@
+pub struct MyParam {
+    param: usize,
+}
+
+#[derive(tidy_builder::Builder)]
+struct MyStruct<'a> {
+    #[builder(default)]
+    my_param: MyParam,
+
+    #[builder(default = 3)]
+    my_usize: usize,
+
+    #[builder(default = 1.2)]
+    my_float: f64,
+
+    #[builder(default = "Name")]
+    my_name: &'a str,
+
+    #[builder(default = false)]
+    my_flag: bool,
+
+    req1: usize,
+    req2: usize,
+    opt1: Option<usize>,
+    opt2: Option<usize>,
+}
+
+fn main() {
+    let my_struct = MyStruct::builder().req1(1).req2(2).build();
+
+    assert_eq!(my_struct.my_param.param, 0);
+    assert_eq!(my_struct.my_usize, 3);
+    assert_eq!(my_struct.my_float, 1.2);
+    assert_eq!(my_struct.my_name, "Name");
+    assert!(!my_struct.my_flag);
+
+    assert_eq!(my_struct.req1, 1);
+    assert_eq!(my_struct.req2, 2);
+
+    assert_eq!(my_struct.opt1, None);
+    assert_eq!(my_struct.opt2, None);
+}

--- a/tests/ui/default_value_for_non_default_field.stderr
+++ b/tests/ui/default_value_for_non_default_field.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `MyParam: Default` is not satisfied
+ --> tests/ui/default_value_for_non_default_field.rs:5:10
+  |
+5 | #[derive(tidy_builder::Builder)]
+  |          ^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `MyParam`
+  |
+  = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `MyParam` with `#[derive(Default)]`
+  |
+1 | #[derive(Default)]
+  |

--- a/tests/ui/repeated_setters_with_the_same_name.stderr
+++ b/tests/ui/repeated_setters_with_the_same_name.stderr
@@ -2,8 +2,18 @@ error[E0308]: mismatched types
  --> tests/ui/repeated_setters_with_the_same_name.rs:9:15
   |
 9 |         .args(vec![])
-  |               ^^^^^^ expected struct `String`, found struct `Vec`
+  |          ---- ^^^^^^ expected struct `String`, found struct `Vec`
+  |          |
+  |          arguments to this function are incorrect
   |
   = note: expected struct `String`
              found struct `Vec<_>`
+note: associated function defined here
+ --> tests/ui/repeated_setters_with_the_same_name.rs:3:5
+  |
+1 | #[derive(tidy_builder::Builder)]
+  |          ---------------------
+2 | pub struct MyStruct {
+3 |     #[builder(each = "args")]
+  |     ^
   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/repeated_setters_with_the_same_name_for_optionals.stderr
+++ b/tests/ui/repeated_setters_with_the_same_name_for_optionals.stderr
@@ -2,8 +2,18 @@ error[E0308]: mismatched types
  --> tests/ui/repeated_setters_with_the_same_name_for_optionals.rs:8:55
   |
 8 |     let my_struct = MyStruct::builder().optional_args(vec![]).build();
-  |                                                       ^^^^^^ expected struct `String`, found struct `Vec`
+  |                                         ------------- ^^^^^^ expected struct `String`, found struct `Vec`
+  |                                         |
+  |                                         arguments to this function are incorrect
   |
   = note: expected struct `String`
              found struct `Vec<_>`
+note: associated function defined here
+ --> tests/ui/repeated_setters_with_the_same_name_for_optionals.rs:3:5
+  |
+1 | #[derive(tidy_builder::Builder)]
+  |          ---------------------
+2 | pub struct MyStruct {
+3 |     #[builder(each = "optional_args")]
+  |     ^
   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
implements support for the `#[builder(default)]` attribute. This attribute has two flavors:
* `#[builder(default)]` which requires the type to implement the `Default` trait.
* `#[builder(default = 0)]`, `#[builder(default = 1.0)]`, ... that allow the user to specify a default value for types like integers, floats, and boolean.

Specifying the `default` attribute on an optional does not have any effect since the default value of an `Option` is `None`.
Fields with the `default` attribute act like optional fields in the sense that they don't change the state of the state machine either.
For now `default` and `each` attributes don't play together which results in `each` having no effect if `default` is provided for a field. This behavior may change in the future.