### PR TITLE
implement the feature for skipping default and optional fields

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -12,6 +12,7 @@ pub enum BuilderError {
     NestedMetaList(syn::MetaList),
     UnknownAttr(syn::Meta),
     UnsupportedType(syn::Type),
+    SkipRequired(syn::Field),
 }
 
 impl From<BuilderError> for proc_macro::TokenStream {
@@ -74,6 +75,11 @@ impl From<BuilderError> for proc_macro::TokenStream {
             }
             BuilderError::UnsupportedType(ty) => {
                 syn::Error::new_spanned(ty, "Only segmented paths are supported")
+                    .into_compile_error()
+                    .into()
+            }
+            BuilderError::SkipRequired(field) => {
+                syn::Error::new_spanned(field, "Cannot skip a required field")
                     .into_compile_error()
                     .into()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,11 @@ pub fn builder(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     let field_ident = &def_field.ident;
                     let field_ty = &def_field.ty;
 
+                    let skip = f_attrs[def_field].skip();
+                    if skip {
+                        continue;
+                    }
+
                     def_setters.push(
                         quote! {
                             pub fn #field_ident(mut self, #field_ident: #field_ty) ->
@@ -220,6 +225,11 @@ pub fn builder(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                             return err.into();
                         }
                     };
+
+                    let skip = f_attrs[opt_field].skip();
+                    if skip {
+                        continue;
+                    }
 
                     let repeated_attr = attrs.repeated();
 
@@ -285,6 +295,11 @@ pub fn builder(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                             return err.into();
                         }
                     };
+
+                    let skip = f_attrs[req_field].skip();
+                    if skip {
+                        return BuilderError::SkipRequired((*req_field).clone()).into();
+                    }
 
                     let repeated_attr = attrs.repeated();
 

--- a/tests/skip_optional_and_defaults.rs
+++ b/tests/skip_optional_and_defaults.rs
@@ -1,0 +1,19 @@
+#[derive(tidy_builder::Builder)]
+struct MyStruct {
+    #[builder(skip)]
+    set_later_opt: Option<usize>,
+
+    #[builder(skip)]
+    #[builder(default = 0)]
+    set_later_def: usize,
+
+    req1: usize,
+}
+
+fn main() {
+    let my_struct = MyStruct::builder().req1(1).build();
+
+    assert_eq!(my_struct.set_later_opt, None);
+    assert_eq!(my_struct.set_later_def, 0);
+    assert_eq!(my_struct.req1, 1);
+}

--- a/tests/ui/call_skipped_setter_of_default.rs
+++ b/tests/ui/call_skipped_setter_of_default.rs
@@ -1,0 +1,13 @@
+#[derive(tidy_builder::Builder)]
+struct MyStruct {
+    #[builder(skip)]
+    set_later_opt: Option<usize>,
+
+    #[builder(skip)]
+    #[builder(default = 0)]
+    set_later_def: usize,
+}
+
+fn main() {
+    let _ = MyStruct::builder().set_later_def();
+}

--- a/tests/ui/call_skipped_setter_of_default.stderr
+++ b/tests/ui/call_skipped_setter_of_default.stderr
@@ -1,0 +1,10 @@
+error[E0599]: no method named `set_later_def` found for struct `MyStructBuilder` in the current scope
+  --> tests/ui/call_skipped_setter_of_default.rs:12:33
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          --------------------- method `set_later_def` not found for this
+...
+12 |     let _ = MyStruct::builder().set_later_def();
+   |                                 ^^^^^^^^^^^^^-- help: remove the arguments
+   |                                 |
+   |                                 field, not a method

--- a/tests/ui/call_skipped_setter_of_optional.rs
+++ b/tests/ui/call_skipped_setter_of_optional.rs
@@ -1,0 +1,13 @@
+#[derive(tidy_builder::Builder)]
+struct MyStruct {
+    #[builder(skip)]
+    set_later_opt: Option<usize>,
+
+    #[builder(skip)]
+    #[builder(default = 0)]
+    set_later_def: usize,
+}
+
+fn main() {
+    let _ = MyStruct::builder().set_later_opt();
+}

--- a/tests/ui/call_skipped_setter_of_optional.stderr
+++ b/tests/ui/call_skipped_setter_of_optional.stderr
@@ -1,0 +1,10 @@
+error[E0599]: no method named `set_later_opt` found for struct `MyStructBuilder` in the current scope
+  --> tests/ui/call_skipped_setter_of_optional.rs:12:33
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          --------------------- method `set_later_opt` not found for this
+...
+12 |     let _ = MyStruct::builder().set_later_opt();
+   |                                 ^^^^^^^^^^^^^-- help: remove the arguments
+   |                                 |
+   |                                 field, not a method

--- a/tests/ui/skip_required_field.rs
+++ b/tests/ui/skip_required_field.rs
@@ -1,0 +1,14 @@
+#[derive(tidy_builder::Builder)]
+struct MyStruct {
+    #[builder(skip)]
+    set_later_opt: Option<usize>,
+
+    #[builder(skip)]
+    #[builder(default = 0)]
+    set_later_def: usize,
+
+    #[builder(skip)]
+    req1: usize,
+}
+
+fn main() {}

--- a/tests/ui/skip_required_field.stderr
+++ b/tests/ui/skip_required_field.stderr
@@ -1,0 +1,6 @@
+error: Cannot skip a required field
+  --> tests/ui/skip_required_field.rs:10:5
+   |
+10 | /     #[builder(skip)]
+11 | |     req1: usize,
+   | |_______________^


### PR DESCRIPTION
implements the `#[builder(skip)]` attribute. This attribute allows skipping of optional and default fields meaning there will be no setters generated for these fields. Optional fields will be set to `None` and default fields will be set to their default values.