### PR TITLE
use traits for better error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 proc-macro2 = "1.0.42"
 quote = "1.0.20"
 syn = { version = "1.0.98", features = ["extra-traits"] }
+convert_case = "0.5.0"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.63.0"

--- a/tests/ui/generics_with_bounds.stderr
+++ b/tests/ui/generics_with_bounds.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<false, true, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<false, true, String>: HasReq1` is not satisfied
   --> tests/ui/generics_with_bounds.rs:12:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 12 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<false, true, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<false, true, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<true, P1, T>`
+note: required by a bound in `MyStructBuilder::<P0, P1, T>::build`
+  --> tests/ui/generics_with_bounds.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/generics_with_bounds_and_where_clause.stderr
+++ b/tests/ui/generics_with_bounds_and_where_clause.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<false, true, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<false, true, String>: HasReq1` is not satisfied
   --> tests/ui/generics_with_bounds_and_where_clause.rs:15:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 15 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<false, true, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<false, true, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<true, P1, T>`
+note: required by a bound in `MyStructBuilder::<P0, P1, T>::build`
+  --> tests/ui/generics_with_bounds_and_where_clause.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/generics_with_const_generics.stderr
+++ b/tests/ui/generics_with_const_generics.stderr
@@ -1,11 +1,27 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>: HasReq1` is not satisfied
   --> tests/ui/generics_with_const_generics.rs:19:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 19 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<'a, 'b, 'c, N, FLG, true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<'a, 'b, 'c, N, FLG, true, P1, T>`
+note: required by a bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+  --> tests/ui/generics_with_const_generics.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>: HasReq2` is not satisfied
+  --> tests/ui/generics_with_const_generics.rs:19:10
+   |
+19 |         .build();
+   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, false, String>`
+   |
+   = help: the trait `HasReq2` is implemented for `MyStructBuilder<'a, 'b, 'c, N, FLG, P0, true, T>`
+note: required by a bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+  --> tests/ui/generics_with_const_generics.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/generics_with_lifetimes.stderr
+++ b/tests/ui/generics_with_lifetimes.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<'_, '_, '_, false, true, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<'_, '_, '_, false, true, String>: HasReq1` is not satisfied
   --> tests/ui/generics_with_lifetimes.rs:20:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 20 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<'_, '_, '_, false, true, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<'_, '_, '_, false, true, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<'a, 'b, 'c, true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<'a, 'b, 'c, true, P1, T>`
+note: required by a bound in `MyStructBuilder::<'a, 'b, 'c, P0, P1, T>::build`
+  --> tests/ui/generics_with_lifetimes.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<'a, 'b, 'c, P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/generics_with_where_clause.stderr
+++ b/tests/ui/generics_with_where_clause.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<true, false, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<true, false, String>: HasReq2` is not satisfied
   --> tests/ui/generics_with_where_clause.rs:15:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 15 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<true, false, String>`
+   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<true, false, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true, T>`
+   = help: the trait `HasReq2` is implemented for `MyStructBuilder<P0, true, T>`
+note: required by a bound in `MyStructBuilder::<P0, P1, T>::build`
+  --> tests/ui/generics_with_where_clause.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/generics_without_bounds.stderr
+++ b/tests/ui/generics_without_bounds.stderr
@@ -1,11 +1,27 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<false, false, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<false, false, String>: HasReq1` is not satisfied
   --> tests/ui/generics_without_bounds.rs:11:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 11 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<false, false, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<false, false, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<true, P1, T>`
+note: required by a bound in `MyStructBuilder::<P0, P1, T>::build`
+  --> tests/ui/generics_without_bounds.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `MyStructBuilder<false, false, String>: HasReq2` is not satisfied
+  --> tests/ui/generics_without_bounds.rs:11:10
+   |
+11 |         .build();
+   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<false, false, String>`
+   |
+   = help: the trait `HasReq2` is implemented for `MyStructBuilder<P0, true, T>`
+note: required by a bound in `MyStructBuilder::<P0, P1, T>::build`
+  --> tests/ui/generics_without_bounds.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/multiple_initialization.stderr
+++ b/tests/ui/multiple_initialization.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, true, String>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, true, String>: HasReq1` is not satisfied
   --> tests/ui/multiple_initialization.rs:25:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 25 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, true, String>`
+   |          ^^^^^ the trait `HasReq1` is not implemented for `MyStructBuilder<'_, '_, '_, {_: usize}, {_: bool}, false, true, String>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<'a, 'b, 'c, N, FLG, true, true, T>`
+   = help: the trait `HasReq1` is implemented for `MyStructBuilder<'a, 'b, 'c, N, FLG, true, P1, T>`
+note: required by a bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+  --> tests/ui/multiple_initialization.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<'a, 'b, 'c, N, FLG, P0, P1, T>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/no_generics.stderr
+++ b/tests/ui/no_generics.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<true, false>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<true, false>: HasReq2` is not satisfied
   --> tests/ui/no_generics.rs:12:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 12 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<true, false>`
+   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<true, false>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true>`
+   = help: the trait `HasReq2` is implemented for `MyStructBuilder<P0, true>`
+note: required by a bound in `MyStructBuilder::<P0, P1>::build`
+  --> tests/ui/no_generics.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/no_generics_reorder.stderr
+++ b/tests/ui/no_generics_reorder.stderr
@@ -1,11 +1,13 @@
-error[E0599]: no method named `build` found for struct `MyStructBuilder<true, false>` in the current scope
+error[E0277]: the trait bound `MyStructBuilder<true, false>: HasReq2` is not satisfied
   --> tests/ui/no_generics_reorder.rs:11:10
    |
-1  | #[derive(tidy_builder::Builder)]
-   |          --------------------- method `build` not found for this
-...
 11 |         .build();
-   |          ^^^^^ method not found in `MyStructBuilder<true, false>`
+   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<true, false>`
    |
-   = note: the method was found for
-           - `MyStructBuilder<true, true>`
+   = help: the trait `HasReq2` is implemented for `MyStructBuilder<P0, true>`
+note: required by a bound in `MyStructBuilder::<P0, P1>::build`
+  --> tests/ui/no_generics_reorder.rs:1:10
+   |
+1  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `MyStructBuilder::<P0, P1>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
with this implementation we kinda have better error messages:

```
error[E0277]: the trait bound `MyStructBuilder<true, false, String>: HasReq2` is not satisfied
  --> tests/ui/generics_with_where_clause.rs:15:10
   |
15 |         .build();
   |          ^^^^^ the trait `HasReq2` is not implemented for `MyStructBuilder<true, false, String>`
   |
   = help: the trait `HasReq2` is implemented for `MyStructBuilder<P0, true, T>`
```

still not the best error message but at least it points to the missing fields and doesn't require nightly.

If you are ok with this implementation I will add `#[rustc_on_unimplemented]` in a separate pull request.