### PR TITLE
use `on_unimplemented` for better error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
-/Cargo.lock
+target
+Cargo.lock

--- a/README.md
+++ b/README.md
@@ -100,3 +100,37 @@ impl MyStructBuilder<true, true> {
     }
 }
 ```
+
+
+### Nightly features
+
+#### Better error messages
+
+In case of a missing fields, error message are like this:
+
+```
+   |
+19 |         .build();
+   |          ^^^^^ the trait `HasReq1` is not implemented for ...
+   |
+```
+
+Which means `req1` is missing. If you are using a **nightly** rust compiler, you can
+have better error messages:
+
+```
+error[E0277]: missing `field2`
+  --> src/main.rs:13:10
+   |
+13 |         .build();
+   |          ^^^^^ provide `field2` before calling `.build()`
+   |
+```
+
+To enable this feature add `better_error` to the crate feature list:
+
+```toml
+tidy-builder = { version="*", features=["better_error"] }
+```
+
+then add `#![feature(rustc_attrs)]` at the top of your root level crate.

--- a/tests/nightly_ui/Cargo.toml
+++ b/tests/nightly_ui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tidy-builder"
+name = "tidy-builder-nightly-test"
 version = "0.1.0"
 edition = "2021"
 description = "tidy-builder is a builder generator that is compile-time correct"
@@ -9,17 +9,8 @@ license = "MIT"
 categories = ["rust-patterns"]
 keywords = ["builder", "builder_pattern"]
 
-[features]
-better_error = []
-
-[lib]
-proc-macro = true
-
 [dependencies]
-proc-macro2 = "1.0.42"
-quote = "1.0.20"
-syn = { version = "1.0.98", features = ["extra-traits"] }
-convert_case = "0.5.0"
+tidy-builder = { path = "../../", features = ["better_error"] }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/tests/nightly_ui/rust-toolchain.toml
+++ b/tests/nightly_ui/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+profile = "default"
+channel = "1.64.0-nightly"

--- a/tests/nightly_ui/src/main.rs
+++ b/tests/nightly_ui/src/main.rs
@@ -1,0 +1,1 @@
+pub fn main() { /* stub */}

--- a/tests/nightly_ui/tests/ui.rs
+++ b/tests/nightly_ui/tests/ui.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/**/*.rs");
+}

--- a/tests/nightly_ui/tests/ui/better_error.rs
+++ b/tests/nightly_ui/tests/ui/better_error.rs
@@ -1,0 +1,14 @@
+#![feature(rustc_attrs)]
+
+#[derive(tidy_builder::Builder)]
+struct Item {
+    field1: Option<usize>,
+    field2: usize,
+}
+
+
+fn main() {
+    let item = Item::builder()
+        .field1(10)
+        .build();
+}

--- a/tests/nightly_ui/tests/ui/better_error.stderr
+++ b/tests/nightly_ui/tests/ui/better_error.stderr
@@ -1,0 +1,14 @@
+error[E0277]: missing `field2`
+  --> tests/ui/better_error.rs:13:10
+   |
+13 |         .build();
+   |          ^^^^^ provide `field2` before calling `.build()`
+   |
+   = help: the trait `HasField2` is not implemented for `ItemBuilder<false>`
+   = help: the trait `HasField2` is implemented for `ItemBuilder<true>`
+note: required by a bound in `ItemBuilder::<P0>::build`
+  --> tests/ui/better_error.rs:3:10
+   |
+3  | #[derive(tidy_builder::Builder)]
+   |          ^^^^^^^^^^^^^^^^^^^^^ required by this bound in `ItemBuilder::<P0>::build`
+   = note: this error originates in the derive macro `tidy_builder::Builder` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,5 +1,19 @@
+use std::process::Command;
+
 #[test]
 fn ui_tests() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/**/*.rs");
+    drop(t); // dropping the `TestCases`, runs the tests
+
+    assert!(std::env::set_current_dir("./tests/nightly_ui").is_ok());
+
+    let result = Command::new("cargo")
+        .args(["+nightly", "test"])
+        .spawn()
+        .unwrap()
+        .wait_with_output()
+        .unwrap()
+        .status;
+    assert!(result.success());
 }


### PR DESCRIPTION
closes #2 

I don't have an easy way to write a UI test for this. Any ideas?

![image](https://user-images.githubusercontent.com/1113944/186654405-c8e71c85-4566-4728-83e6-d55e9f387273.png)
