### PR TITLE
Mark `fn build()` with `pub` visibility

### DIFF
--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -287,7 +287,7 @@ impl<'a> Generator<'a> {
                 #(#opt_setters)*
                 #(#def_setters)*
 
-                fn build(self) -> #s_ident #ty_generics
+                pub fn build(self) -> #s_ident #ty_generics
                     where Self: #(#guard_trait_idents)+*
                 {
                     unsafe {


### PR DESCRIPTION
<img width="784" alt="image" src="https://github.com/user-attachments/assets/0d98a1c8-e833-42db-b1da-589aaf849f0c" />

I assume this is an error and not me using it incorrectly?